### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "CoffeeScript"
   ],
   "dependencies": {
-    "cson-parser": "^1.3.0",
-    "fs-plus": "^3.0.0"
+    "cson-parser": "^1.3.5",
+    "fs-plus": "^3.1.1"
   },
   "devDependencies": {
-    "jasmine-focused": "1.x",
+    "jasmine-focused": "^1.0.7",
     "grunt-contrib-coffee": "~0.9.0",
     "grunt-cli": "~0.1.8",
     "grunt": "~0.4.1",


### PR DESCRIPTION
This PR bumps the dependencies that are still in use after #8 

Although, we still are able to bump `cson-parser` all the way to `4.0.9`, but unfortunately the repo has since been deleted, and specs fail on the latest version. So bumping may not be straightforward or easy.

In any case, this PR still provides the necessary minor bumps to some packages. (note to self, we likely want to publish both `jasmine-focused` and `fs-plus` under pulsar for the changes that have occurred there)